### PR TITLE
Added a new class

### DIFF
--- a/scss/_callouts.scss
+++ b/scss/_callouts.scss
@@ -34,4 +34,7 @@
   &.auto-width {
     width: auto;
   }
+  &.add-shadow {
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
+  }
 }


### PR DESCRIPTION
Show respect to the all new `add-shadow` class for callout which adds shadow behind the callout. Inspired by Google Material Design (maybe). :sunglasses:
